### PR TITLE
fix Allrun

### DIFF
--- a/tutorials/waveFoam/waveFlume/Allrun
+++ b/tutorials/waveFoam/waveFlume/Allrun
@@ -3,7 +3,7 @@
 # Source tutorial run functions
 . $WM_PROJECT_DIR/bin/tools/RunFunctions
 
-exec="../../../bin/prepareCase.sh"
+exec="$WAVES_DIR/bin/prepareCase.sh"
 
 if [ -x "$exec" ]
 then


### PR DESCRIPTION
Fix the error ".../bin/prepareCase.sh is not executable" (because it is executable, this is not the path tested !)