### PR TITLE
Consistent compilation for waveFoam

### DIFF
--- a/applications/solvers/solvers1912_PLUS/waveFoam/Make/files
+++ b/applications/solvers/solvers1912_PLUS/waveFoam/Make/files
@@ -1,3 +1,3 @@
 waveFoam.C
 
-EXE = $(FOAM_APPBIN)/waveFoam
+EXE = $(WAVES_APPBIN)/waveFoam


### PR DESCRIPTION
The make file has a reference to FOAM_APPBIN instead should be WAVES_APPBIN similar to other solvers i.e. waveIsoFoam. In some cases, this may lead to compilation failure especially when sudo apt-get install is used for installing OpenFOAM in a directory that does not have write access.